### PR TITLE
jgit has moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ work.  It turns out that it might.
 
 You probably actually want to be using [jgit][2].
 
-[2]: http://www.jgit.org
+[2]: http://www.eclipse.org/jgit/
 
 ## How do I work with this?
 
@@ -51,6 +51,6 @@ Quick start guide for those unfamiliar with Maven and Eclipse:
 
 ## License
 
-Available under the MIT license (refer to the [LICENSE][2] file).
+Available under the MIT license (refer to the [LICENSE][3] file).
 
 [2]: https://github.com/ethomson/jagged/blob/master/LICENSE


### PR DESCRIPTION
2 corrections: jgit has merged and is now an Eclipse project, so I have updated the URL, plus the links on the front page README were incorrect, both the jgit link and the license link were label [2] and so both pointed to the license file, changed them to be separate.
