### PR TITLE
Repository: report isBare correctly on open

### DIFF
--- a/src/main/java/org/libgit2/jagged/Repository.java
+++ b/src/main/java/org/libgit2/jagged/Repository.java
@@ -29,6 +29,7 @@ public class Repository
         Ensure.argumentNotNullOrEmpty(path, "path");
 
         NativeMethods.repositoryOpen(this, path);
+        bare = NativeMethods.repositoryIsBare(this);
 
         Ensure.nativeNotNull(handle);
     }

--- a/src/main/java/org/libgit2/jagged/core/NativeMethods.java
+++ b/src/main/java/org/libgit2/jagged/core/NativeMethods.java
@@ -126,4 +126,6 @@ public class NativeMethods
     public static native Repository repositoryInit(String path, boolean bare);
 
     public static native void repositoryOpen(Repository repository, String path);
+
+    public static native boolean repositoryIsBare(Repository repository);
 }

--- a/src/main/native/libjagged/repository.c
+++ b/src/main/native/libjagged/repository.c
@@ -125,6 +125,28 @@ Java_org_libgit2_jagged_core_NativeMethods_repositoryHead(
 	return ref_java;
 }
 
+JNIEXPORT jobject JNICALL
+Java_org_libgit2_jagged_core_NativeMethods_repositoryIsBare(
+	JNIEnv *env,
+	jclass class,
+	jobject repo_java)
+{
+	git_repository *repo;
+	git_reference *ref = NULL;
+	jobject ref_java;
+	int error, is_bare;
+
+	assert(env);
+	assert(class);
+	assert(repo_java);
+
+	repo = git_java_handle_get(env, repo_java);
+
+	is_bare = git_repository_is_bare(repo);
+
+	return is_bare ? JNI_TRUE : JNI_FALSE;
+}
+
 JNIEXPORT void JNICALL
 Java_org_libgit2_jagged_core_NativeMethods_repositoryFree(
 	JNIEnv *env,

--- a/src/test/java/org/libgit2/jagged/RepositoryTest.java
+++ b/src/test/java/org/libgit2/jagged/RepositoryTest.java
@@ -65,6 +65,21 @@ public class RepositoryTest
     }
 
     @Test
+    public void testOpenBareRepository()
+    {
+	final File repoPath = getTempDir();
+
+	Repository repository = Repository.init(repoPath.getAbsolutePath(), true);
+	Repository repository2 = new Repository(repoPath.getAbsolutePath());
+
+	Assert.assertTrue(repository.isBare());
+	Assert.assertTrue(repository2.isBare());
+
+	repository.dispose();
+	repository2.dispose();
+    }
+
+    @Test
     public void testClone()
     {
         final File repoPath = setupRepository("testrepo");


### PR DESCRIPTION
When we init a repository, a constructor is called which receives the
'bare' param from the native method. This is not the case in the
"normal" constructor, which opens a repository and thus must ask whether
it is bare or not.

BTW, it looks like your domain name is misspelt in the travis file.
