### PR TITLE
Use uname -m instead of -p

### DIFF
--- a/scripts/arch.mk
+++ b/scripts/arch.mk
@@ -13,7 +13,7 @@ ifeq ($(OS),Linux)
 endif
 
 # Update processor names to canonical format
-ARCH=$(shell uname -p)
+ARCH=$(shell uname -m)
 
 ifeq ($(ARCH),i386)
 	ARCH=x86


### PR DESCRIPTION
The -p option can return arbitrary pieces of information and is 'unkown'
on may distros. The -m options gives us a more appropriate name.
