### PR TITLE
Look up java.io.tmpdir for the temporary dir

### DIFF
--- a/src/test/java/org/libgit2/jagged/GitTest.java
+++ b/src/test/java/org/libgit2/jagged/GitTest.java
@@ -34,6 +34,10 @@ public abstract class GitTest
             {
                 tempRoot = new File(System.getenv("TEMP"));
             }
+            else if (System.getProperty("java.io.tmpdir") != null)
+            {
+                tempRoot = new File(System.getProperty("java.io.tmpdir"));
+            }
             else
             {
                 throw new RuntimeException(


### PR DESCRIPTION
The TMPDIR and TEMP environment variables take precedence, but if
neither are set, fall back to asking the runtime via the java.io.tmpdir
property.
