### PR TITLE
Update to libgit2 0.22.2

### DIFF
--- a/src/main/java/org/libgit2/jagged/core/NativeMethods.java
+++ b/src/main/java/org/libgit2/jagged/core/NativeMethods.java
@@ -23,14 +23,14 @@ public class NativeMethods
         NativeLoader.load("git2");
         NativeLoader.load("jagged");
 
-        globalThreadsInit();
+        globalLibraryInit();
 
         finalizer = new Object()
         {
             @Override
             public void finalize()
             {
-                globalThreadsShutdown();
+                globalLibraryShutdown();
             }
         };
     }
@@ -41,9 +41,9 @@ public class NativeMethods
 
     public static native GitError globalErrorLast();
 
-    public static native void globalThreadsInit();
+    public static native void globalLibraryInit();
 
-    public static native void globalThreadsShutdown();
+    public static native void globalLibraryShutdown();
 
     public static native int globalGetFeatures();
 

--- a/src/main/native/libjagged/global.c
+++ b/src/main/native/libjagged/global.c
@@ -48,25 +48,25 @@ Java_org_libgit2_jagged_core_NativeMethods_globalErrorLast(
 }
 
 JNIEXPORT void JNICALL
-Java_org_libgit2_jagged_core_NativeMethods_globalThreadsInit(
+Java_org_libgit2_jagged_core_NativeMethods_globalLibraryInit(
 	JNIEnv *env,
 	jclass class)
 {
 	GIT_UNUSED(env);
 	GIT_UNUSED(class);
 
-	git_threads_init();
+	git_libgit2_init();
 }
 
 JNIEXPORT void JNICALL
-Java_org_libgit2_jagged_core_NativeMethods_globalThreadsShutdown(
+Java_org_libgit2_jagged_core_NativeMethods_globalLibraryShutdown(
 	JNIEnv *env,
 	jclass class)
 {
 	GIT_UNUSED(env);
 	GIT_UNUSED(class);
 
-	git_threads_shutdown();
+	git_libgit2_shutdown();
 }
 
 JNIEXPORT jint JNICALL

--- a/src/test/java/org/libgit2/jagged/VersionTest.java
+++ b/src/test/java/org/libgit2/jagged/VersionTest.java
@@ -22,7 +22,7 @@ public class VersionTest
         Version libGit2Version = Version.getLibGit2Version();
 
         Assert.assertEquals(0, libGit2Version.getMajor());
-        Assert.assertEquals(21, libGit2Version.getMinor());
-        Assert.assertEquals(3, libGit2Version.getRevision());
+        Assert.assertEquals(22, libGit2Version.getMinor());
+        Assert.assertEquals(2, libGit2Version.getRevision());
     }
 }


### PR DESCRIPTION
The only thing that changed which jagged relies on is the global
initialisation, so the diff ends up being pretty small.