### PR TITLE
[WIP] Maven: building native code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings/
 target/
 /native/
+build.properties

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,99 @@
                     <excludePackageNames>org.libgit2.jagged.core:org.libgit2.jagged.core.*</excludePackageNames>
                 </configuration>
             </plugin>
+
+            <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>properties-maven-plugin</artifactId>
+              <version>1.0-alpha-1</version>
+              <executions>
+                <execution>
+                  <phase>initialize</phase>
+                  <goals>
+                    <goal>read-project-properties</goal>
+                  </goals>
+                  <configuration>
+                    <files>
+                      <file>${basedir}/build.properties</file>
+                    </files>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>clean-native</id>
+                        <phase>clean</phase>
+                        <configuration>
+                            <target>
+                                <echo message="${basedir}/native"/>
+                                <delete dir="${basedir}/native"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>windows</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>compile-native.windows</id>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <target>
+                                        <exec command="make.cmd" failonerror="true">
+                                            <env key="ARCH" value="x86"/>
+                                            <env key="TARGET_PLATFORM" value="${make.targetPlatform}"/>
+                                            <env key="LIBJAGGED_CMAKE_FLAGS" value="-DUSE_SDL=OFF"/>
+                                            <env key="LIBJAGGED_TEST_CMAKE_FLAGS" value="-DUSE_SDL=OFF"/>
+                                        </exec>
+                                        <delete dir="native/win32/x86"/>
+                                        <mkdir dir="native/win32/x86"/>
+                                        <copy file="target/native/libgit2/x86/RelWithDebInfo/git2.dll" todir="native/win32/x86"/>
+                                        <copy file="target/native/libjagged/x86/RelWithDebInfo/jagged.dll" todir="native/win32/x86"/>
+
+                                        <exec command="make.cmd" failonerror="true">
+                                            <env key="ARCH" value="x86_64"/>
+                                            <env key="TARGET_PLATFORM" value="${make.targetPlatform} Win64"/>
+                                            <env key="LIBJAGGED_CMAKE_FLAGS" value="-DUSE_SDL=OFF"/>
+                                            <env key="LIBJAGGED_TEST_CMAKE_FLAGS" value="-DUSE_SDL=OFF"/>
+                                        </exec>
+                                        <delete dir="native/win32/x86_64"/>
+                                        <mkdir dir="native/win32/x86_64"/>
+                                        <copy file="target/native/libgit2/x86_64/RelWithDebInfo/git2.dll" todir="native/win32/x86_64"/>
+                                        <copy file="target/native/libjagged/x86_64/RelWithDebInfo/jagged.dll" todir="native/win32/x86_64"/>
+                                    </target>
+                                </configuration>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>
 


### PR DESCRIPTION
I've now included building of the native libraries for Windows in the pom.xml:

- should we take this approach in general? Then I'll add configurations for Mac and Linux, too.
- should we build both 32-bit and 64-bit binaries at the same time or instead have the target platform configurable in build.properties?
- should we package the libraries into JARs and adjust NativeLoader to (optionally) uncompress the libraries to a temporary directory and load from there? I know this from SWT and JNA and I think it would fit well to Maven's philosophy, too.